### PR TITLE
Upgrade SDK to v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/conductor-sdk/go-sdk-examples
 go 1.17
 
 require (
-	github.com/conductor-sdk/conductor-go v1.3.1
+	github.com/conductor-sdk/conductor-go v1.4.0
 	github.com/sirupsen/logrus v1.8.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/conductor-sdk/conductor-go v1.3.1 h1:Ry2fVq3ij7M9oOsOXrLvTvN14eGOJwMIIrRsmYIvKeA=
 github.com/conductor-sdk/conductor-go v1.3.1/go.mod h1:2c4F/i3UTsEx6kBueQMwf4k1lF5dfOGEztm11c1m54I=
+github.com/conductor-sdk/conductor-go v1.4.0 h1:4Be62DeN2eW5eE+D2sX1dlaPnghaqzH3Aio712+c3h0=
+github.com/conductor-sdk/conductor-go v1.4.0/go.mod h1:2c4F/i3UTsEx6kBueQMwf4k1lF5dfOGEztm11c1m54I=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Upgraded SDK to version `1.4.0`. 

The `USER_NOTIFICATION` example workflow was not working as expected due to issues in `SwitchTask`.

It would always flow through the default case instead of expected decision case because the expression was overridden and `InputParameters["switchCaseValue"]` was incorrect . 

<img width="400" alt="Screenshot 2024-06-28 at 21 34 38" src="https://github.com/conductor-sdk/go-sdk-examples/assets/4755315/3d174658-eb63-49d5-9cfd-dcf2f51c409f">


SEE: https://github.com/conductor-sdk/conductor-go/pull/142